### PR TITLE
feat(backend): added pagination and filter for /get

### DIFF
--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from typing import Optional
 from sqlmodel import select
 from ...models.models import User
 from ...models.schemas.user import UserCreate, UserUpdate, UserPublic, UsersPublic
@@ -8,11 +9,21 @@ user_router = APIRouter()
 
 
 @user_router.get("/", response_model=UsersPublic)
-def list_users(session: SessionDep) -> UsersPublic:
+def list_users(
+    session: SessionDep,
+    offset: int = 0,
+    limit: int = 30,
+    user_role: Optional[str] = None,
+) -> UsersPublic:
     """
     Get all users.
     """
-    users = session.exec(select(User)).all()
+    query = select(User)
+
+    if user_role is not None:
+        query = query.where(User.user_role == user_role)
+
+    users = session.exec(query.offset(offset).limit(limit)).all()
     return UsersPublic(data=[UserPublic.model_validate(user) for user in users])
 
 


### PR DESCRIPTION
## Description

- GET /user/ can be filtered by user_role, default offset = 0, limit = 30
- GET /earthquake/ can be sorted by earthquake_occurred_at, default offset = 0, limit = 30
- GET /event/ can be filtered by zone_id, earthquake_id, event_severity, sort by event_created_at, , default offset = 0, limit = 30
- GET /alert/ can be filtered by alert_state, zone_id, sort by alert_created_at, default offset = 0 limit = 30
- GET /report/ can be filtered by alert_id, user_id, report_factory_zone, sort by report_reported_at, default offset = 0 limit = 30

## Type of change
- [ ] Bug fix
- [X] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [ ] Test
